### PR TITLE
Fix crash when loading on server

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   "license": "GPL-3.0",
   "icon": "assets/rainbowify/icon.png",
 
-  "environment": "*",
+  "environment": "client",
   "entrypoints": {
     "modmenu": [
       "de.lennox.rainbowify.config.modmenu.ModMenuImplementation"


### PR DESCRIPTION
I know that this mod obviously should not be on the server, but I maintain one modpack for both the client and server for simplicity. Most of the time mods mark their environment as client-only, so the mod does not get loaded. 